### PR TITLE
Attempt to fix a couple issues

### DIFF
--- a/include/inv_modulator.h
+++ b/include/inv_modulator.h
@@ -3,7 +3,7 @@
 #include "hardware/pio.h"
 #include "pico/stdlib.h"
 
-void inv_mod_setup(int rf_pin, PIO pio, bool enable_dpsk);
+void inv_mod_setup(int rf_pin, PIO pio);
 
 // Sets datarate to clk_hstx / divider
 void inv_mod_datarate(int divider);

--- a/src/inv_modulator.pio
+++ b/src/inv_modulator.pio
@@ -4,8 +4,8 @@
 
 .fifo txrx
 .clock_div 1
-.in 8 left 8
-.out 1 left auto 1
+.out 8 right auto 8
+.in 1 right
 
 .wrap_target
     // TODO: test if this stalls correctly with autopush instead

--- a/src/main.c
+++ b/src/main.c
@@ -1,18 +1,18 @@
-#include "hardware/pio.h"
 #include "inv_modulator.h"
-#include "pico/stdlib.h"
 
-#define PIN_RF 15
+#define PIN_RF 12
 
 int main() {
     stdio_init_all();
 
-    inv_mod_setup(PIN_RF, pio0, true);
+    inv_mod_setup(PIN_RF, pio0);
     inv_mod_enable(true);
 
-    char *msg = "hello there";
+    char msg[] = "hello there";
 
     while (1) {
-        inv_mod_transmit((uint8_t *) msg, sizeof(msg));
+        inv_mod_transmit((uint8_t*) &msg, sizeof(msg));
+
+        sleep_ms(100);
     }
 }


### PR DESCRIPTION
This PR attempts to fix (I haven't tested it E2E) a couple issues I noticed:
1. HSTX requires input data in order to generate a clock so I set up a dummy transfer
2. Got rid of non-DPSK mode because we can't clear bits with the set alias, but DPSK works with the XOR alias
3. Fixed the swapped `in` and `out` directives in the PIO program